### PR TITLE
Round up the polygon

### DIFF
--- a/polygon-generator.html
+++ b/polygon-generator.html
@@ -81,6 +81,9 @@
                 if(coords_serialize != "")
                     coords_serialize += ", "
                 coords_serialize += coords[i].K + " " + coords[i].G;
+                if(i == coords.length - 1 && coords.length != 1) {
+                    coords_serialize += ", " + coords[0].K + " " + coords[0].G;
+                }
             }
 
             coords = "POLYGON ((" + coords_serialize + "))";


### PR DESCRIPTION
The polygon must be a closed area therefore the initial point must be also added as the last.
